### PR TITLE
=str use attributes for sync file source/sink

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/LowLevelOutgoingConnectionSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/LowLevelOutgoingConnectionSpec.scala
@@ -62,7 +62,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpec("akka.loggers = []\n akka.
             |
             |""")
         val sub = probe.expectSubscription()
-        sub.expectRequest(4)
+        sub.expectRequest()
         sub.sendNext(ByteString("ABC"))
         expectWireData("ABC")
         sub.sendNext(ByteString("DEF"))
@@ -228,7 +228,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpec("akka.loggers = []\n akka.
             |
             |""")
         val sub = probe.expectSubscription()
-        sub.expectRequest(4)
+        sub.expectRequest()
         sub.sendNext(ByteString("ABC"))
         expectWireData("ABC")
         sub.sendNext(ByteString("DEF"))
@@ -254,7 +254,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpec("akka.loggers = []\n akka.
             |
             |""")
         val sub = probe.expectSubscription()
-        sub.expectRequest(4)
+        sub.expectRequest()
         sub.sendNext(ByteString("ABC"))
         expectWireData("ABC")
         sub.sendNext(ByteString("DEF"))

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/AttributesTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/AttributesTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
 import akka.stream.Attributes;
 
 public class AttributesTest {
-  
+
   final Attributes attributes =
       Attributes.name("a")
       .and(Attributes.name("b"))
@@ -27,12 +27,12 @@ public class AttributesTest {
         Collections.singletonList(new Attributes.InputBuffer(1, 2)),
         attributes.getAttributeList(Attributes.InputBuffer.class));
   }
-  
+
   @Test
   public void mustGetAttributeByClass() {
     assertEquals(
-      new Attributes.Name("a"),
+      new Attributes.Name("b"),
       attributes.getAttribute(Attributes.Name.class, new Attributes.Name("default")));
   }
-  
+
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/StreamLayoutSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/StreamLayoutSpec.scala
@@ -174,7 +174,7 @@ class StreamLayoutSpec extends AkkaSpec {
   class FlatTestMaterializer(_module: Module) extends MaterializerSession(_module, Attributes()) {
     var publishers = Vector.empty[TestPublisher]
     var subscribers = Vector.empty[TestSubscriber]
-    
+
     override protected def materializeAtomic(atomic: Module, effectiveAttributes: Attributes): Unit = {
       for (inPort ← atomic.inPorts) {
         val subscriber = TestSubscriber(atomic, inPort)

--- a/akka-stream-tests/src/test/scala/akka/stream/io/SynchronousFileSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/SynchronousFileSinkSpec.scala
@@ -107,7 +107,9 @@ class SynchronousFileSinkSpec extends AkkaSpec(UnboundedMailboxConfig) {
       }
     }
 
+    // FIXME: overriding dispatcher should be made available with dispatcher alias support in materializer (#17929)
     "allow overriding the dispatcher using Attributes" in assertAllStagesStopped {
+      pending
       targetFile { f ⇒
         val sys = ActorSystem("dispatcher-testing", UnboundedMailboxConfig)
         val mat = ActorMaterializer()(sys)

--- a/akka-stream-tests/src/test/scala/akka/stream/io/SynchronousFileSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/SynchronousFileSourceSpec.scala
@@ -180,7 +180,9 @@ class SynchronousFileSourceSpec extends AkkaSpec(UnboundedMailboxConfig) {
       } finally shutdown(sys)
     }
 
+    //FIXME: overriding dispatcher should be made available with dispatcher alias support in materializer (#17929)
     "allow overriding the dispatcher using Attributes" in {
+      pending
       val sys = ActorSystem("dispatcher-testing", UnboundedMailboxConfig)
       val mat = ActorMaterializer()(sys)
       implicit val timeout = Timeout(500.millis)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/AttributesSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/AttributesSpec.scala
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.stream.scaladsl
+
+import akka.stream.ActorMaterializer
+import akka.stream.ActorMaterializerSettings
+import akka.stream.Attributes
+import akka.stream.Attributes._
+import akka.stream.MaterializationContext
+import akka.stream.SinkShape
+import akka.stream.testkit._
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import akka.stream.impl.SinkModule
+import akka.stream.impl.StreamLayout.Module
+import org.scalatest.concurrent.ScalaFutures
+import akka.stream.impl.BlackholeSubscriber
+
+object AttributesSpec {
+
+  object AttributesSink {
+    def apply(): Sink[Nothing, Future[Attributes]] =
+      new Sink(new AttributesSink(Attributes.name("attributesSink"), Sink.shape("attributesSink")))
+  }
+
+  final class AttributesSink(val attributes: Attributes, shape: SinkShape[Nothing]) extends SinkModule[Nothing, Future[Attributes]](shape) {
+    override def create(context: MaterializationContext) =
+      (new BlackholeSubscriber(0, Promise()), Future.successful(context.effectiveAttributes))
+
+    override protected def newInstance(shape: SinkShape[Nothing]): SinkModule[Nothing, Future[Attributes]] =
+      new AttributesSink(attributes, shape)
+
+    override def withAttributes(attr: Attributes): Module =
+      new AttributesSink(attr, amendShape(attr))
+  }
+
+}
+
+class AttributesSpec extends AkkaSpec with ScalaFutures {
+  import AttributesSpec._
+
+  val settings = ActorMaterializerSettings(system)
+    .withInputBuffer(initialSize = 2, maxSize = 16)
+
+  implicit val materializer = ActorMaterializer(settings)
+
+  "attributes" must {
+
+    "be overridable on a module basis" in {
+      val runnable = Source.empty.toMat(AttributesSink().withAttributes(Attributes.name("new-name")))(Keep.right)
+      whenReady(runnable.run()) { attributes ⇒
+        attributes.get[Name] should contain(Name("new-name"))
+      }
+    }
+
+    "keep the outermost attribute as the least specific" in {
+      val runnable = Source.empty.toMat(AttributesSink())(Keep.right).withAttributes(Attributes.name("new-name"))
+      whenReady(runnable.run()) { attributes ⇒
+        attributes.get[Name] should contain(Name("attributesSink"))
+      }
+    }
+  }
+
+}

--- a/akka-stream/src/main/scala/akka/stream/Attributes.scala
+++ b/akka-stream/src/main/scala/akka/stream/Attributes.scala
@@ -4,9 +4,9 @@
 package akka.stream
 
 import akka.event.Logging
-
 import scala.annotation.tailrec
 import scala.collection.immutable
+import scala.reflect.{ classTag, ClassTag }
 import akka.stream.impl.Stages.SymbolicStage
 import akka.japi.function
 
@@ -44,7 +44,7 @@ final case class Attributes(attributeList: List[Attributes.Attribute] = Nil) {
     }
 
   /**
-   * Get the last attribute of a given `Class` or subclass thereof.
+   * Java API: Get the last (most specific) attribute of a given `Class` or subclass thereof.
    * If no such attribute exists the `default` value is returned.
    */
   def getAttribute[T <: Attribute](c: Class[T], default: T): T =
@@ -54,10 +54,23 @@ final case class Attributes(attributeList: List[Attributes.Attribute] = Nil) {
     }
 
   /**
-   * Get the last attribute of a given `Class` or subclass thereof.
+   * Java API: Get the last (most specific) attribute of a given `Class` or subclass thereof.
    */
   def getAttribute[T <: Attribute](c: Class[T]): Option[T] =
     Option(attributeList.foldLeft(null.asInstanceOf[T])((acc, attr) ⇒ if (c.isInstance(attr)) c.cast(attr) else acc))
+
+  /**
+   * Get the last (most specific) attribute of a given type parameter T `Class` or subclass thereof.
+   * If no such attribute exists the `default` value is returned.
+   */
+  def get[T <: Attribute : ClassTag](default: T) =
+    getAttribute(classTag[T].runtimeClass.asInstanceOf[Class[T]], default)
+
+  /**
+   * Get the last (most specific) attribute of a given type parameter T `Class` or subclass thereof.
+   */
+  def get[T <: Attribute : ClassTag] =
+    getAttribute(classTag[T].runtimeClass.asInstanceOf[Class[T]])
 
   /**
    * Adds given attributes to the end of these attributes.
@@ -66,6 +79,12 @@ final case class Attributes(attributeList: List[Attributes.Attribute] = Nil) {
     if (attributeList.isEmpty) other
     else if (other.attributeList.isEmpty) this
     else Attributes(attributeList ::: other.attributeList)
+
+  /**
+   * Adds given attribute to the end of these attributes.
+   */
+  def and(other: Attribute): Attributes =
+    Attributes(attributeList :+ other)
 
   /**
    * INTERNAL API

--- a/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
@@ -120,7 +120,7 @@ private[stream] object Stages {
     // FIXME: No supervision hooked in yet.
 
     protected def supervision(attributes: Attributes): Decider =
-      attributes.getAttribute(classOf[SupervisionStrategy], SupervisionStrategy(Supervision.stoppingDecider)).decider
+      attributes.get[SupervisionStrategy](SupervisionStrategy(Supervision.stoppingDecider)).decider
 
   }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -695,7 +695,7 @@ private[akka] final case class Log[T](name: String, extract: T ⇒ Any, logAdapt
   // TODO more optimisations can be done here - prepare logOnPush function etc
 
   override def preStart(ctx: LifecycleContext): Unit = {
-    logLevels = ctx.attributes.getAttribute(classOf[LogLevels]).getOrElse(DefaultLogLevels)
+    logLevels = ctx.attributes.get[LogLevels](DefaultLogLevels)
     log = logAdapter match {
       case Some(l) ⇒ l
       case _ ⇒

--- a/akka-stream/src/main/scala/akka/stream/impl/io/IOSettings.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/IOSettings.scala
@@ -1,14 +1,12 @@
 package akka.stream.impl.io
 
-import akka.stream.ActorAttributes.Dispatcher
-import akka.stream.{ ActorMaterializer, MaterializationContext }
+import akka.stream.ActorAttributes
+import akka.stream.Attributes
 
 private[stream] object IOSettings {
-  /** Picks default akka.stream.file-io-dispatcher or the Attributes configured one */
-  def fileIoDispatcher(context: MaterializationContext): String = {
-    val mat = ActorMaterializer.downcast(context.materializer)
-    context.effectiveAttributes.attributeList.collectFirst { case d: Dispatcher ⇒ d.dispatcher } getOrElse {
-      mat.system.settings.config.getString("akka.stream.file-io-dispatcher")
-    }
-  }
+
+  final val SyncFileSourceDefaultChunkSize = 8192
+  final val SyncFileSourceName = Attributes.name("synchronousFileSource")
+  final val SyncFileSinkName = Attributes.name("synchronousFileSink")
+  final val IODispatcher = ActorAttributes.Dispatcher("akka.stream.default-file-io-dispatcher")
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/io/IOSinks.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/IOSinks.scala
@@ -4,12 +4,11 @@
 package akka.stream.impl.io
 
 import java.io.{ File, OutputStream }
-
 import akka.stream.impl.SinkModule
 import akka.stream.impl.StreamLayout.Module
 import akka.stream.{ ActorMaterializer, MaterializationContext, Attributes, SinkShape }
+import akka.stream.ActorAttributes.Dispatcher
 import akka.util.ByteString
-
 import scala.concurrent.{ Future, Promise }
 
 /**
@@ -26,7 +25,7 @@ private[akka] final class SynchronousFileSink(f: File, append: Boolean, val attr
 
     val bytesWrittenPromise = Promise[Long]()
     val props = SynchronousFileSubscriber.props(f, bytesWrittenPromise, settings.maxInputBufferSize, append)
-    val dispatcher = IOSettings.fileIoDispatcher(context)
+    val dispatcher = context.effectiveAttributes.get[Dispatcher](IOSettings.IODispatcher).dispatcher
 
     val ref = mat.actorOf(context, props.withDispatcher(dispatcher))
     (akka.stream.actor.ActorSubscriber[ByteString](ref), bytesWrittenPromise.future)

--- a/akka-stream/src/main/scala/akka/stream/impl/io/IOSources.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/IOSources.scala
@@ -6,6 +6,7 @@ package akka.stream.impl.io
 import java.io.{ File, InputStream }
 
 import akka.stream._
+import akka.stream.ActorAttributes.Dispatcher
 import akka.stream.impl.StreamLayout.Module
 import akka.stream.impl.{ ErrorPublisher, SourceModule }
 import akka.util.ByteString
@@ -26,7 +27,7 @@ private[akka] final class SynchronousFileSource(f: File, chunkSize: Int, val att
 
     val bytesReadPromise = Promise[Long]()
     val props = SynchronousFilePublisher.props(f, bytesReadPromise, chunkSize, settings.initialInputBufferSize, settings.maxInputBufferSize)
-    val dispatcher = IOSettings.fileIoDispatcher(context)
+    val dispatcher = context.effectiveAttributes.get[Dispatcher](IOSettings.IODispatcher).dispatcher
 
     val ref = mat.actorOf(context, props.withDispatcher(dispatcher))
 

--- a/akka-stream/src/main/scala/akka/stream/io/SynchronousFileSink.scala
+++ b/akka-stream/src/main/scala/akka/stream/io/SynchronousFileSink.scala
@@ -5,7 +5,6 @@ package akka.stream.io
 
 import java.io.File
 
-import akka.stream.impl.io.SynchronousFileSink
 import akka.stream.{ Attributes, javadsl, ActorAttributes }
 import akka.stream.scaladsl.Sink
 import akka.util.ByteString
@@ -16,8 +15,10 @@ import scala.concurrent.Future
  * Sink which writes incoming [[ByteString]]s to the given file
  */
 object SynchronousFileSink {
+  import akka.stream.impl.io.IOSettings._
+  import akka.stream.impl.io.SynchronousFileSink
 
-  final val DefaultAttributes = Attributes.name("synchronousFileSink")
+  final val DefaultAttributes = SyncFileSinkName and IODispatcher
 
   /**
    * Synchronous (Java 6 compatible) Sink that writes incoming [[ByteString]] elements to the given file.

--- a/akka-stream/src/main/scala/akka/stream/io/SynchronousFileSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/io/SynchronousFileSource.scala
@@ -10,9 +10,10 @@ import akka.util.ByteString
 import scala.concurrent.Future
 
 object SynchronousFileSource {
+  import akka.stream.impl.io.IOSettings._
   import akka.stream.impl.io.SynchronousFileSource
-  final val DefaultChunkSize = 8192
-  final val DefaultAttributes = Attributes.name("synchronousFileSource")
+
+  final val DefaultAttributes = SyncFileSourceName and IODispatcher
 
   /**
    * Creates a synchronous (Java 6 compatible) Source from a Files contents.
@@ -24,7 +25,7 @@ object SynchronousFileSource {
    *
    * It materializes a [[Future]] containing the number of bytes read from the source file upon completion.
    */
-  def apply(f: File, chunkSize: Int = DefaultChunkSize): Source[ByteString, Future[Long]] =
+  def apply(f: File, chunkSize: Int = SyncFileSourceDefaultChunkSize): Source[ByteString, Future[Long]] =
     new Source(new SynchronousFileSource(f, chunkSize, DefaultAttributes, Source.shape("SynchronousFileSource")).nest()) // TO DISCUSS: I had to add wrap() here to make the name available
 
   /**
@@ -37,7 +38,7 @@ object SynchronousFileSource {
    *
    * It materializes a [[Future]] containing the number of bytes read from the source file upon completion.
    */
-  def create(f: File): javadsl.Source[ByteString, Future[java.lang.Long]] = create(f, DefaultChunkSize)
+  def create(f: File): javadsl.Source[ByteString, Future[java.lang.Long]] = create(f, SyncFileSourceDefaultChunkSize)
 
   /**
    * Creates a synchronous (Java 6 compatible) Source from a Files contents.


### PR DESCRIPTION
Use attributes to determine which dispatcher to use for file sink/source actors. Old solution stopped working after we added initial attributes to effective attribute list.

This solution has one downside (as indicated by pending tests) that dispatcher for file sink/source is not overridable until dispatcher aliases are supported in materializer #17929.