### PR TITLE
=str ignore tests that use StatefulStage

### DIFF
--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowTest.java
@@ -16,6 +16,7 @@ import akka.stream.testkit.AkkaSpec;
 import akka.stream.testkit.TestPublisher;
 import akka.testkit.JavaTestKit;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.reactivestreams.Publisher;
 import scala.concurrent.Await;
@@ -179,7 +180,7 @@ public class FlowTest extends StreamTest {
   }
 
 
-  @Test
+  @Ignore("StatefulStage to be converted to GraphStage when Java Api is available (#18817)") @Test
   public void mustBeAbleToUseTransform() {
     final JavaTestKit probe = new JavaTestKit(system);
     final Iterable<Integer> input = Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7);
@@ -204,15 +205,15 @@ public class FlowTest extends StreamTest {
                   return emit(Arrays.asList(element, element).iterator(), ctx);
                 }
               }
-              
+
             };
           }
-          
+
           @Override
           public TerminationDirective onUpstreamFinish(Context<Integer> ctx) {
             return terminationEmit(Collections.singletonList(sum).iterator(), ctx);
           }
-          
+
         };
       }
     });
@@ -355,12 +356,12 @@ public class FlowTest extends StreamTest {
     return new akka.japi.function.Creator<Stage<T, T>>() {
       @Override
       public PushPullStage<T, T> create() throws Exception {
-        return new PushPullStage<T, T>() {  
+        return new PushPullStage<T, T>() {
           @Override
           public SyncDirective onPush(T element, Context<T> ctx) {
             return ctx.push(element);
           }
-          
+
           @Override
           public SyncDirective onPull(Context<T> ctx) {
             return ctx.pull();
@@ -374,17 +375,17 @@ public class FlowTest extends StreamTest {
   public void mustBeAbleToUseMerge() throws Exception {
     final Flow<String, String, BoxedUnit> f1 =
         Flow.of(String.class).transform(FlowTest.this.<String> op()).named("f1");
-    final Flow<String, String, BoxedUnit> f2 = 
+    final Flow<String, String, BoxedUnit> f2 =
         Flow.of(String.class).transform(FlowTest.this.<String> op()).named("f2");
     @SuppressWarnings("unused")
-    final Flow<String, String, BoxedUnit> f3 = 
+    final Flow<String, String, BoxedUnit> f3 =
         Flow.of(String.class).transform(FlowTest.this.<String> op()).named("f3");
 
     final Source<String, BoxedUnit> in1 = Source.from(Arrays.asList("a", "b", "c"));
     final Source<String, BoxedUnit> in2 = Source.from(Arrays.asList("d", "e", "f"));
 
     final Sink<String, Publisher<String>> publisher = Sink.publisher();
-    
+
     final Source<String, BoxedUnit> source = Source.fromGraph(
             FlowGraph.create(new Function<FlowGraph.Builder<BoxedUnit>, SourceShape<String>>() {
               @Override

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/SourceTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/SourceTest.java
@@ -20,6 +20,7 @@ import akka.stream.testkit.AkkaSpec;
 import akka.stream.testkit.TestPublisher;
 import akka.testkit.JavaTestKit;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import scala.concurrent.Await;
 import scala.concurrent.Future;
@@ -107,7 +108,7 @@ public class SourceTest extends StreamTest {
     probe.expectMsgEquals("()");
   }
 
-  @Test
+  @Ignore("StatefulStage to be converted to GraphStage when Java Api is available (#18817)") @Test
   public void mustBeAbleToUseTransform() {
     final JavaTestKit probe = new JavaTestKit(system);
     final Iterable<Integer> input = Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7);
@@ -415,7 +416,7 @@ public class SourceTest extends StreamTest {
   @Test
   public void mustProduceTicks() throws Exception {
     final JavaTestKit probe = new JavaTestKit(system);
-    Source<String, Cancellable> tickSource = Source.from(FiniteDuration.create(1, TimeUnit.SECONDS), 
+    Source<String, Cancellable> tickSource = Source.from(FiniteDuration.create(1, TimeUnit.SECONDS),
         FiniteDuration.create(500, TimeUnit.MILLISECONDS), "tick");
     Cancellable cancellable = tickSource.to(Sink.foreach(new Procedure<String>() {
       public void apply(String elem) {
@@ -457,7 +458,7 @@ public class SourceTest extends StreamTest {
     String result = Await.result(future2, probe.dilated(FiniteDuration.create(3, TimeUnit.SECONDS)));
     assertEquals("A", result);
   }
-  
+
   @Test
   public void mustRepeat() throws Exception {
     final Future<List<Integer>> f = Source.repeat(42).grouped(10000).runWith(Sink.<List<Integer>> head(), materializer);
@@ -465,7 +466,7 @@ public class SourceTest extends StreamTest {
     assertEquals(result.size(), 10000);
     for (Integer i: result) assertEquals(i, (Integer) 42);
   }
-  
+
   @Test
   public void mustBeAbleToUseActorRefSource() throws Exception {
     final JavaTestKit probe = new JavaTestKit(system);


### PR DESCRIPTION
Tests to be enabled again after https://github.com/akka/akka/issues/18817